### PR TITLE
WMO as authority codes for coordinate operations

### DIFF
--- a/MetOceanDWG Projects/Authority Codes for CRS/Pressure as Z coordinate.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pressure as Z coordinate.md
@@ -1,0 +1,77 @@
+# Parametric datum for pressure measurements
+
+This page describe a more exploratory work compared to the proposal on coordinate operations.
+
+## Problem statement
+
+_Note: the following discussion with vertical datum is only for illustrating the problem. We are not
+suggesting to use them for pressure measurements._
+
+For vertical height measurement, the EPSG database provide datum for various surfaces
+from which measurements can be done. For example:
+
+```
+VerticalDatum["Low Water", Id["EPSG", 1093, URI["urn:ogc:def:datum:EPSG::1093"]]]
+VerticalDatum["High Water", Id["EPSG", 1094, URI["urn:ogc:def:datum:EPSG::1094"]]]
+VerticalDatum["Lower Low Water Large Tide", Id["EPSG", 1083, URI[ …omitted… ]]]
+```
+
+Above datum allow the construction of vertical CRS with meter units.
+We do not need to provide full CRS definitions;
+data providers can assemble axis direction (up or down) and linear unit of their choice with above datum.
+But the datum identification is significant.
+
+**Use case:** if a software wants to report depths on a nautical chart for navigation purpose,
+it shall show depths at the lowest possible tide.
+The software may need to recognize “Lower Low Water Large Tide” as the desired datum
+and rejects depths expressed with other datum (if we don't apply any datum shift).
+Parsing the datum name as a text is not reliable. Checking the authority datum code
+is a more machine-readable way to check if the datum is okay for reporting depths on a nautical chart.
+Above works for heights measured in meters,
+but there is no authority codes for identifying parametric datum for pressure measurements.
+
+
+### Questions
+
+[ISO 19162 §12.4](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html#97) gives the following example:
+
+```
+PARAMETRICCRS["WMO standard atmosphere layer 0",
+  PDATUM["Mean Sea Level", ANCHOR["1013.25 hPa at 15°C"]],
+  CS[parametric, 1],
+  AXIS["pressure (hPa)", up],
+  PARAMETRICUNIT["HectoPascal", 100.0]]
+```
+
+Do we have WMO or UCAR codes for specifying the surface from which pressure measurements are done
+(_“Mean Sea Level”_ in above example)?
+The reason is similar to the _“Lower Low Water Large Tide”_ example:
+a software may accept only data relative to some expected datum.
+
+Grib2 code table 4.5 — Fixed Surface Types and Units — defines the following entries:
+
+> Code: 108
+> Meaning: Level at Specified Pressure Difference from Ground to Level
+> Unit: Pa
+
+Is it suitable for defining the datum of coordinates measured as (pressured on the ground)
+− (pressure at the measured location)? Is the following correct?
+
+```
+ParametricCRS[“Elevation as pressure difference”,
+  ParametricDatum["Level at Specified Pressure Difference from Ground to Level",
+    ID["WMO", 108, URI["urn:ogc:def:datum:WMO::108"]]],
+  CS[parametric, 1],
+  AXIS["pressure (Pa)", up],
+  PARAMETRICUNIT["Pascal", 1.0]]]
+```
+
+Questions:
+
+* Which WMO tables and codes can be used as datum definitions
+  (in addition of table 4.5 code 108 shown above, if correct).
+* `URI["urn:ogc:def:datum:WMO::108"]` does not include table number.
+  Does WMO has codes that are unique across Grib tables?
+* What does _“Axis direction: up”_ means in a context where coordinate values are increasing downward
+  (case of pressure)? ISO 19162 said: _“axis positive direction is up relative to gravity”_.
+  Is _“axis positive direction”_ synonymous of _“direction of increasing values”_?

--- a/MetOceanDWG Projects/Authority Codes for CRS/README.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/README.md
@@ -1,0 +1,98 @@
+# Authority Codes for CRS definitions
+
+This directory proposes a mapping from standard definitions provided by organizations
+such as the World Meteorological Organization (WMO) to Coordinate Reference System objects.
+The use of alternative authorities aims to complement the use of EPSG codes
+when CRS commonly used in the meteorological domain is not found in the EPSG geodetic dataset.
+Following discussion takes _Rotated pole_ as an example but can apply to any projection method
+currently not in the EPSG database.
+
+## Problem statement
+[ISO 19162 §14.3.2](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html#116)
+provides an example of a geographic CRS with pole rotation.
+Following WKT is derived from that example and discussion on the mailing list.
+The important things for this discussion are the `METHOD` and `PARAMETER` elements.
+
+```
+GEOGCRS["Atlantic Pole",
+  BASEGEOGCRS["Based upon sphere",
+    DATUM["Based on GRS 1980 Authalic Sphere",
+    ELLIPSOID["GRS 1980 Authalic Sphere", 6371007, 0, LENGTHUNIT["metre", 1]]],
+  DERIVINGCONVERSION["Atlantic pole",
+    METHOD["Pole rotation", ID["Authority", 1234]],
+    PARAMETER["Latitude of rotated pole", 52.0,
+      ANGLEUNIT["degree", 0.0174532925199433]],
+    PARAMETER["Longitude of rotated pole", -30.0,
+      ANGLEUNIT["degree", 0.0174532925199433]],
+    PARAMETER["Axis rotation", -25.0,
+      ANGLEUNIT["degree", 0.0174532925199433]]],
+  CS[ellipsoidal, 2],
+    AXIS["latitude", north, ORDER[1]],
+    AXIS["longitude", east, ORDER[2]],
+    ANGLEUNIT["degree", 0.0174532925199433]]
+```
+
+A CRS definition, no matter if expressed in GML or WKT,
+have 3 components that are controlled vocabulary defined by external authorities
+(i.e. not code lists or enumerations defined by ISO 19111 or WKT specification):
+
+* The operation method.
+* The operation parameters.
+* The datum (in some cases).
+
+The operation method (“Pole rotation” in above example) identifies the set of equations.
+It would be too complex and too verbose to encode the equations in a WKT or GML definition.
+For this reason, the `METHOD` element is only a reference to formulas published by an authority.
+Two sources of formulas are:
+
+* IOGP Publication 373-7-2 – Geomatics Guidance Note number 7, part 2:
+  _Coordinate Conversions and Transformations including Formulas._
+  https://epsg.org/guidance-notes.html
+* OGC 01-009: OpenGIS Implementation Specification: _Coordinate Transformation Services,_
+  section 10.6.1: Cartographic Projection Transform Parameters.
+
+The OGC 01-009 document is legacy (it actually does not give all formulas) and should be replaced by IOGP document.
+But the operation and parameter names given by OGC 01-009 §10.6.1 are still in common use.
+
+**Example:** when a WKT contains the following element:
+
+```
+METHOD[“Lambert Conic Conformal (1SP)”, ID[“EPSG”, 9801]]
+```
+
+It actually refers to formulas published in section 3.1.1.2 of IOGP 373-7-2 (March 2020).
+The parameters associated to this operation method are listed in table 2 of that document,
+and are also given in the EPSG geodetic database.
+Those formulas have to be hard-coded in the map projection library;
+it would be too difficult to design a WKT, GML or JSON format that allows the encoding of complete formulas.
+
+Using `METHOD` and `PARAMETER` elements,
+it is possible to write inter-operable definitions for CRS that are not in the EPSG database,
+for example by providing parameter values that are different than the values of all CRS in the EPSG database.
+But the `METHOD` (together with its set of parameters) must be defined by some authority,
+otherwise the CRS definition would be specific to a particular implementation.
+
+OGC 05-010 _URNs of definitions in ogc namespace_ recommendation paper defines object types
+for operations methods and their parameters.
+Examples (note that 9801, 8801 and 8802 are not CRS codes in this context):
+
+| Example                            | Meaning                       |
+| ---------------------------------- | ----------------------------- |
+| `urn:ogc:def:method:EPSG::9801`    | Lambert Conic Conformal (1SP) |
+| `urn:ogc:def:parameter:EPSG::8801` | Latitude of natural origin    |
+| `urn:ogc:def:parameter:EPSG::8802` | Longitude of natural origin   |
+
+The problem is that there is currently no authority code for “Pole Rotation” operation method.
+It can been seen from the `ID[“Authority”, 1234]` placeholder in the WKT example published in ISO 19162.
+
+
+## Proposal
+
+Define URN in “urn:ogc:def:method:WMO” namespace as references to templates published in the WML Manual of Codes.
+This proposal is detailled in the following pages:
+
+* [WMO as a source of authority codes for coordinate operations](WMO.md)
+
+Following page is a more exploratory work:
+
+* [Pressure as Z coordinate](Pressure%20as%20Z%20coordinate.md)

--- a/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
+++ b/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:DerivedCRS
+  xsi:schemaLocation = "http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/coordinateReferenceSystems.xsd"
+  xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml          = "http://www.opengis.net/gml/3.2"
+  xmlns:gmd          = "http://www.isotc211.org/2005/gmd"
+  xmlns:gco          = "http://www.isotc211.org/2005/gco"
+  xmlns:xlink        = "http://www.w3.org/1999/xlink"
+  gml:id="cosmo-crs-101">
+  <gml:identifier codeSpace="COSMO">urn:ogc:def:crs:COSMO::101</gml:identifier>
+  <gml:name codeSpace="COSMO">COSMO reference system</gml:name>
+  <gml:remarks>Tentative CRS definition. May change in any future version.</gml:remarks>
+  <gml:domainOfValidity>
+    <gmd:EX_Extent>
+      <gmd:description>
+        <gco:CharacterString>Park of (TODO).</gco:CharacterString>
+      </gmd:description>
+      <gmd:geographicElement>
+        <gmd:EX_GeographicBoundingBox>
+            <gmd:extentTypeCode>
+              <gco:Boolean>true</gco:Boolean>
+            </gmd:extentTypeCode>
+            <gmd:westBoundLongitude>
+              <gco:Decimal>10</gco:Decimal>         <!-- TODO -->
+            </gmd:westBoundLongitude>
+            <gmd:eastBoundLongitude>
+              <gco:Decimal>80</gco:Decimal>         <!-- TODO -->
+            </gmd:eastBoundLongitude>
+            <gmd:southBoundLatitude>
+              <gco:Decimal>40</gco:Decimal>         <!-- TODO -->
+            </gmd:southBoundLatitude>
+            <gmd:northBoundLatitude>
+              <gco:Decimal>60</gco:Decimal>         <!-- TODO -->
+            </gmd:northBoundLatitude>
+        </gmd:EX_GeographicBoundingBox>
+      </gmd:geographicElement>
+    </gmd:EX_Extent>
+  </gml:domainOfValidity>
+  <gml:scope>Specific to COSMO project.</gml:scope>     <!-- TODO -->
+  <gml:conversion>
+    <gml:Conversion gml:id="RotatedLatLon">
+      <gml:identifier codeSpace="COSMO">urn:ogc:def:coordinateOperation:COSMO::100</gml:identifier>
+      <gml:name codeSpace="COSMO">Rotated Latitude Longitude</gml:name>
+      <gml:scope>Specific to COSMO project.</gml:scope>                                     <!-- TODO -->
+      <gml:method>
+        <gml:OperationMethod gml:id="PoleRotation">
+          <gml:identifier codeSpace="WMO">urn:ogc:def:method:WMO:2019:3.1</gml:identifier>  <!-- TODO (WMO) -->
+          <gml:name codeSpace="WMO">Pole Rotation</gml:name>
+          <gml:formula>See WMO. Manual on Codes. No. 306, volume 1.2, parts B and C.</gml:formula>
+          <gml:sourceDimensions>2</gml:sourceDimensions>
+          <gml:targetDimensions>2</gml:targetDimensions>
+          <!--
+            TODO: See WMO.md for a definition of parameters.
+            The parameters below do not match exactly the definitions of WMO template 3.1.
+          -->
+          <gml:parameter>
+            <gml:OperationParameter gml:id="PoleLatitude">
+              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
+              <gml:name codeSpace="WMO">Latitude of rotated pole</gml:name>
+            </gml:OperationParameter>
+          </gml:parameter>
+          <gml:parameter>
+            <gml:OperationParameter gml:id="PoleLongitude">
+              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
+              <gml:name codeSpace="WMO">Longitude of rotated pole</gml:name>
+            </gml:OperationParameter>
+          </gml:parameter>
+          <gml:parameter>
+            <gml:OperationParameter gml:id="AxisRotation">
+              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
+              <gml:name codeSpace="WMO">Axis rotation</gml:name>
+            </gml:OperationParameter>
+          </gml:parameter>
+        </gml:OperationMethod>
+      </gml:method>
+      <gml:parameterValue>
+        <gml:ParameterValue>
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">40.0</gml:value>                      <!-- TODO -->
+          <gml:operationParameter xlink:href="#PoleLatitude"></gml:operationParameter>
+        </gml:ParameterValue>
+      </gml:parameterValue>
+      <gml:parameterValue>
+        <gml:ParameterValue>
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">-170.0</gml:value>                    <!-- TODO -->
+          <gml:operationParameter xlink:href="#PoleLongitude"></gml:operationParameter>
+        </gml:ParameterValue>
+      </gml:parameterValue>
+      <gml:parameterValue>
+        <gml:ParameterValue>
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">10.0</gml:value>                      <!-- TODO -->
+          <gml:operationParameter xlink:href="#AxisRotation"></gml:operationParameter>
+        </gml:ParameterValue>
+      </gml:parameterValue>
+    </gml:Conversion>
+  </gml:conversion>
+  <gml:baseCRS>
+    <gml:GeodeticCRS gml:id="cosmo-crs-100">
+      <gml:identifier codeSpace="COSMO">urn:ogc:def:crs:COSMO::100</gml:identifier>
+      <gml:name codeSpace="COSMO">COSMO base geodetic CRS</gml:name>
+      <gml:scope>Specific to COSMO project.</gml:scope>
+      <gml:ellipsoidalCS>
+        <gml:EllipsoidalCS gml:id="epsg-cs-6422">
+          <gml:identifier codeSpace="IOGP">urn:ogc:def:cs:EPSG:9.9.1:6422</gml:identifier>
+          <gml:name>Ellipsoidal CS: East (°), North (°).</gml:name>
+          <gml:axis>
+            <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="epsg-axis-106">
+              <gml:identifier codeSpace="IOGP">urn:ogc:def:axis:EPSG:9.9.1:106</gml:identifier>
+              <gml:name codeSpace="EPSG:9.9.1">Geodetic latitude</gml:name>
+              <gml:axisAbbrev>φ</gml:axisAbbrev>
+              <gml:axisDirection codeSpace="ISO">north</gml:axisDirection>
+              <gml:minimumValue>-90.0</gml:minimumValue>
+              <gml:maximumValue>90.0</gml:maximumValue>
+              <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
+            </gml:CoordinateSystemAxis>
+          </gml:axis>
+          <gml:axis>
+            <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="epsg-axis-107">
+              <gml:identifier codeSpace="IOGP">urn:ogc:def:axis:EPSG:9.9.1:107</gml:identifier>
+              <gml:name codeSpace="EPSG:9.9.1">Geodetic longitude</gml:name>
+              <gml:axisAbbrev>λ</gml:axisAbbrev>
+              <gml:axisDirection codeSpace="ISO">east</gml:axisDirection>
+              <gml:minimumValue>-180.0</gml:minimumValue>
+              <gml:maximumValue>180.0</gml:maximumValue>
+              <gml:rangeMeaning codeSpace="ISO">wraparound</gml:rangeMeaning>
+            </gml:CoordinateSystemAxis>
+          </gml:axis>
+        </gml:EllipsoidalCS>
+      </gml:ellipsoidalCS>
+      <gml:geodeticDatum>
+        <gml:GeodeticDatum gml:id="COSMOKugel">
+          <gml:identifier codeSpace="COSMOS">urn:ogc:def:datum:COSMO::100</gml:identifier>
+          <gml:name>COSMO Kugel</gml:name>
+          <gml:scope>Specific to COSMO project.</gml:scope>
+          <gml:primeMeridian>
+            <gml:PrimeMeridian gml:id="epsg-meridian-8901">
+              <gml:identifier codeSpace="IOGP">urn:ogc:def:meridian:EPSG::8901</gml:identifier>
+              <gml:name>Greenwich</gml:name>
+              <gml:greenwichLongitude uom="urn:ogc:def:uom:EPSG::9102">0.0</gml:greenwichLongitude>
+            </gml:PrimeMeridian>
+          </gml:primeMeridian>
+          <gml:ellipsoid>
+            <gml:Ellipsoid gml:id="Erdkugel">
+              <gml:identifier codeSpace="COSMOS">urn:ogc:def:ellipsoid:COSMO::100</gml:identifier>
+              <gml:name>Erdkugel</gml:name>
+              <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6371229.0</gml:semiMajorAxis>
+              <gml:secondDefiningParameter>
+                <gml:SecondDefiningParameter>
+                  <gml:isSphere>true</gml:isSphere>
+                </gml:SecondDefiningParameter>
+              </gml:secondDefiningParameter>
+            </gml:Ellipsoid>
+          </gml:ellipsoid>
+        </gml:GeodeticDatum>
+      </gml:geodeticDatum>
+    </gml:GeodeticCRS>
+  </gml:baseCRS>
+  <gml:derivedCRSType codeSpace="ISO">GeodeticCRS</gml:derivedCRSType>
+  <gml:coordinateSystem>
+    <gml:EllipsoidalCS gml:id="rotated-CS">
+      <gml:identifier codeSpace="COSMO">urn:ogc:def:cs:COSMO::101</gml:identifier>
+      <gml:name>Ellipsoidal rotated CS.</gml:name>
+      <gml:axis>
+        <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-latitude">
+          <gml:identifier codeSpace="COSMO">urn:ogc:def:axis:COSMO::101</gml:identifier>
+          <gml:name>Rotated latitude</gml:name>
+          <gml:axisAbbrev>φ</gml:axisAbbrev>
+          <gml:axisDirection codeSpace="COSMO">north</gml:axisDirection>
+          <gml:minimumValue>-90.0</gml:minimumValue>
+          <gml:maximumValue>90.0</gml:maximumValue>
+          <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
+        </gml:CoordinateSystemAxis>
+      </gml:axis>
+      <gml:axis>
+        <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-longitude">
+          <gml:identifier codeSpace="COSMO">urn:ogc:def:axis:COSMO::102</gml:identifier>
+          <gml:name>Rotated longitude</gml:name>
+          <gml:axisAbbrev>λ</gml:axisAbbrev>
+          <gml:axisDirection codeSpace="COSMO">east</gml:axisDirection>
+          <gml:minimumValue>-180.0</gml:minimumValue>
+          <gml:maximumValue>180.0</gml:maximumValue>
+          <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
+        </gml:CoordinateSystemAxis>
+      </gml:axis>
+    </gml:EllipsoidalCS>
+  </gml:coordinateSystem>
+</gml:DerivedCRS>

--- a/MetOceanDWG Projects/Authority Codes for CRS/WMO.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/WMO.md
@@ -1,0 +1,56 @@
+# WMO as a source of authority codes for coordinate operations
+
+The problem statement is described in the [README](README.md) page.
+This page describes the proposal using WMO as a source of authoritative definitions.
+
+
+
+## Proposal for coordinate operations
+
+Define URN in “urn:ogc:def:method:WMO” namespace as below as references to templates in the following document:
+
+* [WMO. Manual on Codes. No. 306, volume 1.2, parts B and C.](https://library.wmo.int/doc_num.php?explnum_id=10310)
+
+Syntax (edition is optional; if omitted, latest edition is assumed):
+
+```
+urn:ogc:def:method:WMO:edition:template
+```
+
+Example for Pole Rotation:
+
+```
+urn:ogc:def:method:WMO:2019:3.1
+```
+
+For making the definition clearer, OGC should publish the operation method name together with its parameters.
+The following is adapted from WMO template 3.1:
+
+> Operation method name: “rotated latitude/longitude”
+> Operation method code: urn:ogc:def:method:WMO:2019:3.1
+> Parameters:
+>
+> * Latitude of the southern pole of projection
+> * Longitude of the southern pole of projection
+> * Angle of rotation of projection
+>
+> Three parameters define a general latitude/longitude coordinate system,
+> formed by a general rotation of the sphere. One choice for these parameters is:
+>
+> (a) The geographic latitude in degrees of the southern pole of the coordinate system, θ p ;
+> (b) The geographic longitude in degrees of the southern pole of the coordinate system, λ p ;
+> (c) The angle of rotation in degrees about the new polar axis (measured clockwise when
+> looking from the southern to the northern pole) of the coordinate system, assuming the new
+> axis to have been obtained by first rotating the sphere through λ p degrees about the geographic
+> polar axis, and then rotating through (90 + θ p ) degrees so that the southern pole moved along
+> the (previously rotated) Greenwich meridian.
+
+Templates 3.2 and 3.3 may also be provided.
+
+
+
+### Open questions:
+
+ * What kind of OGC document would it be?
+ * How would it appears in OGC Naming Authority?
+ * Do we have a WMO contact for checking with them if this proposal makes sense?


### PR DESCRIPTION
This is a copy of the [Rotated pole (PDF)](https://portal.ogc.org/files/?artifact_id=97873) pending document which was presented in OGC June 2021 virtual meeting.  This commit creates a new `MetOceanDWG Projects/Authority Codes for CRS` directory with 3 files. The part about WMO codes is in the `WMO.md` page. The page about the use of parametric datum is considered exploratory work and isolated in a separated page.
