### PR TITLE
"Pole rotation" parameter definitions proposal

### DIFF
--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -1,0 +1,124 @@
+# OGC as a source of authority codes for pole rotation
+
+The preferred way to define the pole rotation method would be to
+leave the task to expert in this field, [such as WMO](WMO.md).
+As a fallback, this page provides a proposal for OGC definition.
+We try to combine the example provided in
+[ISO 19162 §14.3.2](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html#116) together with
+[Rotated pole in CF-conventions](https://cfconventions.org/cf-conventions/cf-conventions.html#_rotated_pole)
+and WMO Manual on Codes template 3.1.
+
+There is two operation methods, depending if the rotation is applied on the north pole or the south pole.
+For each operation, the name used in the UCAR netCDF library are shown.
+All proposals below are identical to ISO 19162 §14.3.2 example
+except for "North" or "South" prefix before operation name.
+
+
+
+
+## South pole rotation
+
+* **Proposal:** `South pole rotation`
+* **WMO name:** `Rotated Latitude/longitude`
+* **CF name:**  (none) — UCAR netCDF library uses `rotated_latlon_grib`
+
+
+### Parameters
+
+| Proposal                  | Name in UCAR library        |
+| ------------------------- | --------------------------- |
+| Latitude of rotated pole  | `grid_south_pole_latitude`  |
+| Longitude of rotated pole | `grid_south_pole_longitude` |
+| Axis rotation             | `grid_south_pole_angle`     |
+
+
+### Formula
+
+(Adapted from GRIB template 3.1):
+The rotations are applied by first rotating the sphere through λ<sub>p</sub> about the geographic polar axis,
+then rotating through (φ<sub>p</sub> − (−90°)) degrees so that the southern pole moved along the (previously rotated) Greenwich meridian,
+and finally by rotating clockwise when looking from the southern to the northern rotated pole.
+
+* Definitions:
+  * (φ, λ) the (latitude, longitude) to rotate.
+  * (φ<sub>p</sub>, λ<sub>p</sub>) the (latitude, longitude) of rotated pole.
+  * θ the axis rotation about the new polar axis measured clockwise when looking from the southern to the northern pole.
+* First rotation:
+  * Δλ = λ − λ<sub>p</sub>
+* To Cartesian coordinates
+  * x = cos(φ) ⋅ cos(Δλ)
+  * y = cos(φ) ⋅ sin(Δλ)
+  * z = sin(φ)
+* Useful trigonometric identities:
+  * sin(φ + 90°) =  cos(φ)
+  * cos(φ + 90°) = −sin(φ)
+* Rotate φ<sub>p</sub> − (−90°)
+  * x<sub>t</sub> =  cos(φ<sub>p</sub>) ⋅ z − sin(φ<sub>p</sub>) ⋅ x
+  * y<sub>t</sub> =  y
+  * z<sub>t</sub> = −cos(φ<sub>p</sub>) ⋅ x − sin(φ<sub>p</sub>) ⋅ z
+* To spherical coordinates
+  * R = √(x<sub>t</sub>² + y<sub>t</sub>²)
+  *  φ<sub>t</sub> = atan2(z<sub>t</sub>, R)
+  * Δλ<sub>t</sub> = atan2(y<sub>t</sub>, x<sub>t</sub>)
+* Axis rotation
+  * λ<sub>t</sub> = Δλ<sub>t</sub> − θ
+
+
+
+
+## North pole rotation
+
+* **Proposal:** `North pole rotation`
+* **WMO name:**  (none)
+* **CF name:**  `rotated_latitude_longitude` (see note below)
+* **PROJ:**     `-I +proj=ob_tran +o_proj=longlat`
+
+
+### Parameters
+
+The PROJ parameters define the _inverse_ operation,
+because of differences in the way those parameters are defined.
+The `-I` option in above PROJ definition gets the forward (inverse of inverse) operation.
+
+| Proposal                  | CF-convention name          | PROJ name  |
+| ------------------------- | --------------------------- | ---------- |
+| Latitude of rotated pole  | `grid_north_pole_latitude`  | `+o_lat_p` |
+| Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p` |
+| Axis rotation             | `north_pole_grid_longitude` | `+lon_0`   |
+
+
+### Formula
+
+Similar to the south pole rotation except that the latitude rotation is (φ<sub>p</sub> − 90°) degrees
+and the final rotation is clockwise when looking from the northern to the southern rotated pole.
+
+* First rotation:
+  * Δλ = λ − λ<sub>p</sub>
+* To Cartesian coordinates
+  * x = cos(φ) ⋅ cos(Δλ)
+  * y = cos(φ) ⋅ sin(Δλ)
+  * z = sin(φ)
+* Useful trigonometric identities:
+  * sin(φ − 90°) = −cos(φ)
+  * cos(φ − 90°) =  sin(φ)
+* Rotate φ<sub>p</sub> − 90°
+  * x<sub>t</sub> = −cos(φ<sub>p</sub>) ⋅ z + sin(φ<sub>p</sub>) ⋅ x
+  * y<sub>t</sub> =  y
+  * z<sub>t</sub> =  cos(φ<sub>p</sub>) ⋅ x + sin(φ<sub>p</sub>) ⋅ z
+* To spherical coordinates
+  * R = √(x<sub>t</sub>² + y<sub>t</sub>²)
+  *  φ<sub>t</sub> = atan2(z<sub>t</sub>, R)
+  * Δλ<sub>t</sub> = atan2(y<sub>t</sub>, x<sub>t</sub>)
+* Axis rotation
+  * λ<sub>t</sub> = Δλ<sub>t</sub> + θ
+
+
+**Note:** `ucar.unidata.geoloc.projection.RotatedPole` in UCAR netCDF library version 5.5.2 gives results
+with an offset of 180° in longitude values compared to what we would expect from a geometrical reasoning:
+if we rotate the pole to 60°N, then latitude of 59°N on Greenwich meridian become only 1° below new pole,
+i.e. 89°N, but still on the same meridian (Greenwich) because we did not cross the pole. Conversely 61°N
+is still at 89°N relative to the rotated pole, but on the other size of the pole, i.e. at longitude 180°.
+But `RotatedPole` gives opposite longitude values (180° and 0° respectively).
+
+The "South pole rotation" method of netCDF library is consistent with this geometrical reasoning.
+We do not know if the difference observed for "North pole rotation" is intended or not.

--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -113,11 +113,19 @@ and the final rotation is clockwise when looking from the northern to the southe
   * λ<sub>t</sub> = Δλ<sub>t</sub> + θ
 
 
-**Note:** `ucar.unidata.geoloc.projection.RotatedPole` in UCAR netCDF library version 5.5.2 gives results
+#### Open question
+Axis rotation has been defined as "clockwise when looking from the northern to the southern rotated pole"
+for symmetry with the definition in South pole case.
+But it causes a change of sign (+θ instead of −θ) for the last term in above formula.
+Should be change the definition in a way that keep the same sign,
+for example by replacing "clockwise" by "counter-clockwise" in the North pole case?
+
+#### Open issue
+`ucar.unidata.geoloc.projection.RotatedPole` in UCAR netCDF library version 5.5.2 gives results
 with an offset of 180° in longitude values compared to what we would expect from a geometrical reasoning:
 if we rotate the pole to 60°N, then latitude of 59°N on Greenwich meridian become only 1° below new pole,
 i.e. 89°N, but still on the same meridian (Greenwich) because we did not cross the pole. Conversely 61°N
-is still at 89°N relative to the rotated pole, but on the other size of the pole, i.e. at longitude 180°.
+is still at 89°N relative to the rotated pole, but on the other side of the pole, i.e. at longitude 180°.
 But `RotatedPole` gives opposite longitude values (180° and 0° respectively).
 
 The "South pole rotation" method of netCDF library is consistent with this geometrical reasoning.

--- a/MetOceanDWG Projects/Authority Codes for CRS/README.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/README.md
@@ -92,6 +92,7 @@ Define URN in “urn:ogc:def:method:WMO” namespace as references to templates 
 This proposal is detailled in the following pages:
 
 * [WMO as a source of authority codes for coordinate operations](WMO.md)
+* [OGC as a source of authority codes for pole rotation](Pole%20rotation.md)
 
 Following page is a more exploratory work:
 

--- a/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
+++ b/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
@@ -44,50 +44,46 @@
       <gml:scope>Specific to COSMO project.</gml:scope>                                     <!-- TODO -->
       <gml:method>
         <gml:OperationMethod gml:id="PoleRotation">
-          <gml:identifier codeSpace="WMO">urn:ogc:def:method:WMO:2019:3.1</gml:identifier>  <!-- TODO (WMO) -->
-          <gml:name codeSpace="WMO">Pole Rotation</gml:name>
-          <gml:formula>See WMO. Manual on Codes. No. 306, volume 1.2, parts B and C.</gml:formula>
+          <gml:identifier codeSpace="COSMO">urn:ogc:def:method:COSMO::100</gml:identifier>
+          <gml:name codeSpace="COSMO">Pole rotation (netCDF CF convention)</gml:name>
+          <gml:formula>See netCDF-CF conventions, section "Rotated Pole".</gml:formula>
           <gml:sourceDimensions>2</gml:sourceDimensions>
           <gml:targetDimensions>2</gml:targetDimensions>
-          <!--
-            TODO: See WMO.md for a definition of parameters.
-            The parameters below do not match exactly the definitions of WMO template 3.1.
-          -->
           <gml:parameter>
             <gml:OperationParameter gml:id="PoleLatitude">
-              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
-              <gml:name codeSpace="WMO">Latitude of rotated pole</gml:name>
+              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::101</gml:identifier>
+              <gml:name codeSpace="COSMO">Grid north pole latitude</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
           <gml:parameter>
             <gml:OperationParameter gml:id="PoleLongitude">
-              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
-              <gml:name codeSpace="WMO">Longitude of rotated pole</gml:name>
+              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::102</gml:identifier>
+              <gml:name codeSpace="COSMO">Grid north pole longitude</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
           <gml:parameter>
             <gml:OperationParameter gml:id="AxisRotation">
-              <gml:identifier codeSpace="WMO">urn:ogc:def:parameter:WMO::TODO</gml:identifier>
-              <gml:name codeSpace="WMO">Axis rotation</gml:name>
+              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::103</gml:identifier>
+              <gml:name codeSpace="COSMO">North pole grid longitude</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
         </gml:OperationMethod>
       </gml:method>
       <gml:parameterValue>
         <gml:ParameterValue>
-          <gml:value uom="urn:ogc:def:uom:EPSG::9102">40.0</gml:value>                      <!-- TODO -->
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">39.25</gml:value>
           <gml:operationParameter xlink:href="#PoleLatitude"></gml:operationParameter>
         </gml:ParameterValue>
       </gml:parameterValue>
       <gml:parameterValue>
         <gml:ParameterValue>
-          <gml:value uom="urn:ogc:def:uom:EPSG::9102">-170.0</gml:value>                    <!-- TODO -->
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">-162</gml:value>
           <gml:operationParameter xlink:href="#PoleLongitude"></gml:operationParameter>
         </gml:ParameterValue>
       </gml:parameterValue>
       <gml:parameterValue>
         <gml:ParameterValue>
-          <gml:value uom="urn:ogc:def:uom:EPSG::9102">10.0</gml:value>                      <!-- TODO -->
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">0</gml:value>
           <gml:operationParameter xlink:href="#AxisRotation"></gml:operationParameter>
         </gml:ParameterValue>
       </gml:parameterValue>
@@ -128,7 +124,7 @@
       </gml:ellipsoidalCS>
       <gml:geodeticDatum>
         <gml:GeodeticDatum gml:id="COSMOKugel">
-          <gml:identifier codeSpace="COSMOS">urn:ogc:def:datum:COSMO::100</gml:identifier>
+          <gml:identifier codeSpace="COSMO">urn:ogc:def:datum:COSMO::100</gml:identifier>
           <gml:name>COSMO Kugel</gml:name>
           <gml:scope>Specific to COSMO project.</gml:scope>
           <gml:primeMeridian>
@@ -140,7 +136,7 @@
           </gml:primeMeridian>
           <gml:ellipsoid>
             <gml:Ellipsoid gml:id="Erdkugel">
-              <gml:identifier codeSpace="COSMOS">urn:ogc:def:ellipsoid:COSMO::100</gml:identifier>
+              <gml:identifier codeSpace="COSMO">urn:ogc:def:ellipsoid:COSMO::100</gml:identifier>
               <gml:name>Erdkugel</gml:name>
               <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6371229.0</gml:semiMajorAxis>
               <gml:secondDefiningParameter>


### PR DESCRIPTION
This is a proposal to define more precisely two "Pole rotation" coordinate operation methods: one for north pole and one for south pole. This pull request creates a new `pole rotation.md` page.