### PR TITLE
Revisit "North pole rotation" definition, add example

### DIFF
--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -18,22 +18,24 @@ except for "North" or "South" prefix before operation name.
 
 ## South pole rotation
 
-* **Proposal:** `South pole rotation`
-* **WMO name:** `Rotated Latitude/longitude`
-* **CF name:**  (none) — UCAR netCDF library uses `rotated_latlon_grib`
+| Authority                 | Name or identifier            |
+| ------------------------- | ----------------------------- |
+| OGC identifier (proposal) | `urn:ogc:def:method:OGC::100` |
+| OGC name (proposal)       | `South pole rotation`         |
+| WMO name                  | `Rotated Latitude/longitude`  |
+| Name in UCAR library      | `rotated_latlon_grib`         |
 
 
 ### Parameters
 
-| Proposal                  | Name in UCAR library        |
-| ------------------------- | --------------------------- |
-| Latitude of rotated pole  | `grid_south_pole_latitude`  |
-| Longitude of rotated pole | `grid_south_pole_longitude` |
-| Axis rotation             | `grid_south_pole_angle`     |
+| Identifier proposal              | Name proposal             | Name in UCAR library        |
+| -------------------------------- | ------------------------- | --------------------------- |
+| `urn:ogc:def:parameter:OGC::101` | Latitude of rotated pole  | `grid_south_pole_latitude`  |
+| `urn:ogc:def:parameter:OGC::102` | Longitude of rotated pole | `grid_south_pole_longitude` |
+| `urn:ogc:def:parameter:OGC::103` | Axis rotation             | `grid_south_pole_angle`     |
 
 
 ### Formula
-
 (Adapted from GRIB template 3.1):
 The rotations are applied by first rotating the sphere through λ<sub>p</sub> about the geographic polar axis,
 then rotating through (φ<sub>p</sub> − (−90°)) degrees so that the southern pole moved along the (previously rotated) Greenwich meridian,
@@ -50,8 +52,8 @@ and finally by rotating clockwise when looking from the southern to the northern
   * y = cos(φ) ⋅ sin(Δλ)
   * z = sin(φ)
 * Useful trigonometric identities:
-  * sin(φ + 90°) =  cos(φ)
-  * cos(φ + 90°) = −sin(φ)
+  * sin(φ<sub>p</sub> + 90°) =  cos(φ<sub>p</sub>)
+  * cos(φ<sub>p</sub> + 90°) = −sin(φ<sub>p</sub>)
 * Rotate φ<sub>p</sub> − (−90°)
   * x<sub>t</sub> =  cos(φ<sub>p</sub>) ⋅ z − sin(φ<sub>p</sub>) ⋅ x
   * y<sub>t</sub> =  y
@@ -67,28 +69,29 @@ and finally by rotating clockwise when looking from the southern to the northern
 
 
 ## North pole rotation
+Note: the PROJ parameters in this section will apply to the _inverse_ operation,
+because of differences in the way those parameters are defined.
+The `-I` option in PROJ definition below gets the forward (inverse of inverse) operation.
 
-* **Proposal:** `North pole rotation`
-* **WMO name:**  (none)
-* **CF name:**  `rotated_latitude_longitude` (see note below)
-* **PROJ:**     `-I +proj=ob_tran +o_proj=longlat`
+| Authority                 | Name or identifier                 |
+| ------------------------- | ---------------------------------- |
+| OGC identifier (proposal) | `urn:ogc:def:method:OGC::110`      |
+| OGC name (proposal)       | `North pole rotation`              |
+| WMO name                  | (none)                             |
+| CF-convention name        | `rotated_latitude_longitude`       |
+| PROJ definition           | `-I +proj=ob_tran +o_proj=longlat` |
 
 
 ### Parameters
 
-The PROJ parameters define the _inverse_ operation,
-because of differences in the way those parameters are defined.
-The `-I` option in above PROJ definition gets the forward (inverse of inverse) operation.
-
-| Proposal                  | CF-convention name          | PROJ name  |
-| ------------------------- | --------------------------- | ---------- |
-| Latitude of rotated pole  | `grid_north_pole_latitude`  | `+o_lat_p` |
-| Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p` |
-| Axis rotation             | `north_pole_grid_longitude` | `+lon_0`   |
+| Identifier proposal              | Name proposal             | CF-convention name          | PROJ name  |
+| -------------------------------- | ------------------------- | --------------------------- | ---------- |
+| `urn:ogc:def:parameter:OGC::111` | Latitude of rotated pole  | `grid_north_pole_latitude`  | `+o_lat_p` |
+| `urn:ogc:def:parameter:OGC::112` | Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p` |
+| `urn:ogc:def:parameter:OGC::113` | Axis rotation             | `north_pole_grid_longitude` | `+lon_0`   |
 
 
 ### Formula
-
 Similar to the south pole rotation except that the latitude rotation is (φ<sub>p</sub> − 90°) degrees
 and the final rotation is clockwise when looking from the northern to the southern rotated pole.
 
@@ -99,8 +102,8 @@ and the final rotation is clockwise when looking from the northern to the southe
   * y = cos(φ) ⋅ sin(Δλ)
   * z = sin(φ)
 * Useful trigonometric identities:
-  * sin(φ − 90°) = −cos(φ)
-  * cos(φ − 90°) =  sin(φ)
+  * sin(φ<sub>p</sub> − 90°) = −cos(φ<sub>p</sub>)
+  * cos(φ<sub>p</sub> − 90°) =  sin(φ<sub>p</sub>)
 * Rotate φ<sub>p</sub> − 90°
   * x<sub>t</sub> = −cos(φ<sub>p</sub>) ⋅ z + sin(φ<sub>p</sub>) ⋅ x
   * y<sub>t</sub> =  y
@@ -130,3 +133,69 @@ But `RotatedPole` gives opposite longitude values (180° and 0° respectively).
 
 The "South pole rotation" method of netCDF library is consistent with this geometrical reasoning.
 We do not know if the difference observed for "North pole rotation" is intended or not.
+
+
+## Rotated ellipsoidal coordinate system
+The coordinate operation results are (latitude, longitude) coordinates on a rotated sphere.
+The "Geodetic latitude" and "Geodetic longitude" axis names of coordinate system EPSG:6422
+may not be applicable anymore.
+The following defines a new coordinate system with different axis names.
+
+| Object class           | Identifier proposal         | Name proposal           |
+| ---------------------- | --------------------------- | ----------------------- |
+| `EllipsoidalCS`        | `urn:ogc:def:cs:OGC::100`   | Ellipsoidal rotated CS. |
+| `CoordinateSystemAxis` | `urn:ogc:def:axis:OGC::101` | Rotated latitude        |
+| `CoordinateSystemAxis` | `urn:ogc:def:axis:OGC::102` | Rotated longitude       |
+
+### Open issue
+Axis names are constrained by [ISO 19111 table 27](http://docs.opengeospatial.org/as/18-005r5/18-005r5.html#table_27),
+and above names are not in the list of permitted axis names.
+
+
+
+# Example with COSMO meteorological model
+The [RotatedPole.xml](RotatedPole.xml) file gives an example of CRS definition in GML.
+It uses the following identifiers in COSMO namespace.
+In this example, those definitions are considered specific to COSMO model
+and would not be stored on an OGC or WMO server.
+Instead the COSMO project would need to maintain their own registry.
+
+| Object class    | Identifier example                           | Name example                            |
+| --------------- | -------------------------------------------- | --------------------------------------- |
+| `DerivedCRS`    | `urn:ogc:def:crs:COSMO::101`                 | COSMO-DWD rotated pole grid             |
+| `Conversion`    | `urn:ogc:def:coordinateOperation:COSMO::101` | COSMO-DE pole rotation                  |
+| `GeodeticCRS`   | `urn:ogc:def:crs:COSMO::100`                 | COSMO DWD base geodetic CRS (spherical) |
+| `GeodeticDatum` | `urn:ogc:def:datum:COSMO::100`               | COSMO DWD geodetic datum (spherical)    |
+| `Ellipsoid`     | `urn:ogc:def:ellipsoid:COSMO::100`           | COSMO DWD models sphere                 |
+
+
+The GML file passes XML validation. Parsing with Apache SIS gives the following WKT:
+
+```
+GEODCRS["COSMO-DWD rotated pole grid",
+  BASEGEODCRS["COSMO DWD base geodetic CRS (Spherical)",
+    DATUM["COSMO DWD geodetic datum (Spherical)",
+      ELLIPSOID["DWD Models Sphere", 6371229.0, 0.0, LENGTHUNIT["metre", 1]]],
+      PRIMEM["Greenwich", 0.0, ANGLEUNIT["degree", 0.017453292519943295]]],
+  DERIVINGCONVERSION["COSMO-DE pole rotation",
+    METHOD["North pole rotation", ID["OGC", 110]],
+    PARAMETER["Latitude of rotated pole", 40.0, ANGLEUNIT["degree", 0.017453292519943295]],
+    PARAMETER["Longitude of rotated pole", -170.0, ANGLEUNIT["degree", 0.017453292519943295]],
+    PARAMETER["Axis rotation", 0.0, ANGLEUNIT["degree", 0.017453292519943295]]],
+  CS[ellipsoidal, 2],
+    AXIS["Rotated latitude (B)", north, ORDER[1]],
+    AXIS["Rotated longitude (L)", east, ORDER[2]],
+    ANGLEUNIT["degree", 0.017453292519943295],
+  SCOPE["Atmospheric model data."],
+  AREA["Central Germany."],
+  BBOX[47.00, 5.00, 55.00, 15.00],
+  ID["COSMO", 101],
+  REMARK["Used with grid spacing of 0.025° in rotated coordinates."]]
+```
+
+Converting a central point in Germany (51.1657°N 10.4515°E) gives about (1.1666°N 179.71682°W).
+It was tested with both Apache SIS using XML definition and PROJ using following command line:
+
+```
+cs2cs -I "EPSG:4326" +to +type=crs +proj=ob_tran +o_proj=longlat +datum=WGS84 +no_defs +o_lat_p=40 +o_lon_p=-170
+```

--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -161,6 +161,17 @@ Axis names are constrained by [ISO 19111 table 27](http://docs.opengeospatial.or
 and above names are not in the list of permitted axis names.
 
 
+### XML definition files
+Two components could be subject to OGC standardisation and are provided as GML files:
+
+* [PoleRotation.xml](PoleRotation.xml) defines the operation method described in this page.
+* [RotatedCS.xml](RotatedCS.xml) defines the ellipsoidal coordinate system described above.
+
+Above are only components, not fully defined CRS.
+While above components could be used for any CRS based on rotated pole,
+a fully CRS can only be specific to a particular meteorological model (or other application).
+The next section gives an example.
+
 
 # Example with COSMO meteorological model
 The [RotatedPole.xml](RotatedPole.xml) file gives an example of CRS definition in GML.

--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -107,8 +107,11 @@ The `-I` option in above PROJ definition gets the forward (inverse of inverse) o
 | `urn:ogc:def:parameter:OGC::112` | Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p`         |
 | `urn:ogc:def:parameter:OGC::113` | Axis rotation             | `north_pole_grid_longitude` | `+lon_0` antipodal |
 
-Note: the value given to PROJ `+lon_0` parameter needs to be the axis rotation value with a shift of ±180°.
+**Note on PROJ parameters:**
+The value given to PROJ `+lon_0` parameter needs to be the axis rotation value with a shift of ±180°.
 If there is no axis rotation, then `+lon_0=180` needs to be specified.
+Alternatively, the `-I` option can be avoided by swapping the `+lon_0` and `+o_lon_p` values
+(the +180 offset stay on `+lon_0`).
 
 
 ### Formula

--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -240,19 +240,17 @@ Output:
 
 ## PROJ command line
 The following command-line can be executed on a Unix system.
-Note that this command pretends that the CRS uses the WGS84 datum.
-This is not exact; the COSMO definition uses a datum close (but not identical)
+Note that the COSMO model uses a sphere which is close, but not identical,
 to _International 1924 Authalic Sphere_ (`urn:ogc:def:datum:EPSG::6053`).
+We use EPSG:4053 CRS as a close approximation.
 However the `ob_tran` method ignores the ellipsoid, because formulas are applied on a sphere
 (like all other implementations tested on this page)
 and the source and target coordinates are geographic coordinates on the same sphere.
-The use of "WGS84" and "EPSG:4326" below are geodetically wrong,
-but we abuse them for the convenience of using well-known aliases in this command-line
-with the knowledge that PROJ will ignore them.
-See Apache SIS case for a discussion on the impact of the datum on output coordinates.
+Replacing "EPSG:4053" (International 1924) by "EPSG:4326" (WGS 1984) on PROJ 8.2.0
+does not change the outout coordinates.
 
 ```shell
-cs2cs -I "EPSG:4326" +to +type=crs +proj=ob_tran +o_proj=longlat +datum=WGS84 +no_defs \
+cs2cs -I "EPSG:4053" +to +type=crs +proj=ob_tran +o_proj=longlat +R=6371229 +no_defs \
       +o_lat_p=40 +o_lon_p=-170 +lon_0=180 -f %g <<< "10.4515 51.1657"
 ```
 
@@ -262,9 +260,12 @@ Output:
 1.16655	0.283179 0
 ```
 
-Reminder: despite the datum specified in command-line, above inputs are **not** WGS 84 coordinates.
-They are closer to "International 1924" coordinates. See discussion about datum below.
+**Reminder:** input coordinates (or output coordinates in inverse operation)
+above are **not** WGS 1984 (EPSG:4326) geographic coordinates.
+They are closer to "International 1924" coordinates.
+There is a potential difference of about 20 km in Central Germany.
 If desired, transformation from/to WGS 84 can be added using more PROJ parameters.
+See Apache SIS case below for more discussion on the impact of the datum on output coordinates.
 
 
 ## Apache SIS

--- a/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
+++ b/MetOceanDWG Projects/Authority Codes for CRS/Pole rotation.md
@@ -17,6 +17,8 @@ except for "North" or "South" prefix before operation name.
 
 
 ## South pole rotation
+This is the operation defined by GRIB template 3.1.
+Also used as the base operation from which the "North pole rotation" case will be derived.
 
 | Authority                 | Name or identifier            |
 | ------------------------- | ----------------------------- |
@@ -36,10 +38,10 @@ except for "North" or "South" prefix before operation name.
 
 
 ### Formula
-(Adapted from GRIB template 3.1):
 The rotations are applied by first rotating the sphere through λ<sub>p</sub> about the geographic polar axis,
 then rotating through (φ<sub>p</sub> − (−90°)) degrees so that the southern pole moved along the (previously rotated) Greenwich meridian,
 and finally by rotating clockwise when looking from the southern to the northern rotated pole.
+The 180° rotated meridian runs through both the geographical and the rotated South pole.
 
 * Definitions:
   * (φ, λ) the (latitude, longitude) to rotate.
@@ -59,19 +61,29 @@ and finally by rotating clockwise when looking from the southern to the northern
   * y<sub>t</sub> =  y
   * z<sub>t</sub> = −cos(φ<sub>p</sub>) ⋅ x − sin(φ<sub>p</sub>) ⋅ z
 * To spherical coordinates
-  * R = √(x<sub>t</sub>² + y<sub>t</sub>²)
-  *  φ<sub>t</sub> = atan2(z<sub>t</sub>, R)
+  *  φ<sub>t</sub> = asin(z<sub>t</sub>)
   * Δλ<sub>t</sub> = atan2(y<sub>t</sub>, x<sub>t</sub>)
 * Axis rotation
   * λ<sub>t</sub> = Δλ<sub>t</sub> − θ
 
 
+### Inverse operation
+Conversion from the rotated CRS to the geographic CRS can be done using the same "South pole rotation" method,
+but with all parameters with subscript <var>p</var> replaced by following parameters with subscript <var>g</var>:
+
+* φ<sub>g</sub>  = φ<sub>p</sub>
+* λ<sub>g</sub>  = copySign(180, θ<sub>p</sub>) - θ<sub>p</sub>
+* θ<sub>g</sub>  = copySign(180, λ<sub>p</sub>) - λ<sub>p</sub>
+
+`copySign(180, x)` is a function returning 180 with the same sign than <var>x</var>.
+In above formulas, it is used for applying a shift of 180° (for antipodal longitude)
+in such a way that the resulting angle stay in the [−180 … 180]° range.
+
 
 
 ## North pole rotation
-Note: the PROJ parameters in this section will apply to the _inverse_ operation,
-because of differences in the way those parameters are defined.
-The `-I` option in PROJ definition below gets the forward (inverse of inverse) operation.
+We found no authoritative source defining this operation.
+This section describes what seems a common usage.
 
 | Authority                 | Name or identifier                 |
 | ------------------------- | ---------------------------------- |
@@ -81,58 +93,55 @@ The `-I` option in PROJ definition below gets the forward (inverse of inverse) o
 | CF-convention name        | `rotated_latitude_longitude`       |
 | PROJ definition           | `-I +proj=ob_tran +o_proj=longlat` |
 
+Note: the PROJ parameters in this section will apply to the _inverse_ operation,
+because proposed OGC parameters are defined as latitude/longitude of the rotated pole,
+while PROJ parameters are latitude/longitude of the north pole expressed in the rotated CRS.
+The `-I` option in above PROJ definition gets the forward (inverse of inverse) operation.
+
 
 ### Parameters
 
-| Identifier proposal              | Name proposal             | CF-convention name          | PROJ name  |
-| -------------------------------- | ------------------------- | --------------------------- | ---------- |
-| `urn:ogc:def:parameter:OGC::111` | Latitude of rotated pole  | `grid_north_pole_latitude`  | `+o_lat_p` |
-| `urn:ogc:def:parameter:OGC::112` | Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p` |
-| `urn:ogc:def:parameter:OGC::113` | Axis rotation             | `north_pole_grid_longitude` | `+lon_0`   |
+| Identifier proposal              | Name proposal             | CF-convention name          | PROJ name          |
+| -------------------------------- | ------------------------- | --------------------------- | ------------------ |
+| `urn:ogc:def:parameter:OGC::111` | Latitude of rotated pole  | `grid_north_pole_latitude`  | `+o_lat_p`         |
+| `urn:ogc:def:parameter:OGC::112` | Longitude of rotated pole | `grid_north_pole_longitude` | `+o_lon_p`         |
+| `urn:ogc:def:parameter:OGC::113` | Axis rotation             | `north_pole_grid_longitude` | `+lon_0` antipodal |
+
+Note: the value given to PROJ `+lon_0` parameter needs to be the axis rotation value with a shift of ±180°.
+If there is no axis rotation, then `+lon_0=180` needs to be specified.
 
 
 ### Formula
-Similar to the south pole rotation except that the latitude rotation is (φ<sub>p</sub> − 90°) degrees
-and the final rotation is clockwise when looking from the northern to the southern rotated pole.
+The rotations are applied by first rotating the sphere through λ<sub>p</sub> about the geographic polar axis,
+then rotating through (φ<sub>p</sub> − 90°) degrees so that the northern pole moved along the (previously rotated) Greenwich meridian,
+and finally by rotating clockwise when looking from the northern to the southern rotated pole.
+The 0° rotated meridian is defined as the meridian that runs through both the geographical and the rotated North pole.
 
-* First rotation:
-  * Δλ = λ − λ<sub>p</sub>
-* To Cartesian coordinates
-  * x = cos(φ) ⋅ cos(Δλ)
-  * y = cos(φ) ⋅ sin(Δλ)
-  * z = sin(φ)
-* Useful trigonometric identities:
-  * sin(φ<sub>p</sub> − 90°) = −cos(φ<sub>p</sub>)
-  * cos(φ<sub>p</sub> − 90°) =  sin(φ<sub>p</sub>)
-* Rotate φ<sub>p</sub> − 90°
-  * x<sub>t</sub> = −cos(φ<sub>p</sub>) ⋅ z + sin(φ<sub>p</sub>) ⋅ x
-  * y<sub>t</sub> =  y
-  * z<sub>t</sub> =  cos(φ<sub>p</sub>) ⋅ x + sin(φ<sub>p</sub>) ⋅ z
-* To spherical coordinates
-  * R = √(x<sub>t</sub>² + y<sub>t</sub>²)
-  *  φ<sub>t</sub> = atan2(z<sub>t</sub>, R)
-  * Δλ<sub>t</sub> = atan2(y<sub>t</sub>, x<sub>t</sub>)
-* Axis rotation
-  * λ<sub>t</sub> = Δλ<sub>t</sub> + θ
+No formula is derived for the North pole case.
+Instead the "South pole rotation" method should be used for rotating the antipodal point of the rotated north pole.
+This approach automatically inserts a shift of 180° in longitude values, as required for above 0° meridian definition.
+More specifically, a "North pole rotation" with parameters identified by the subscript <var>N</var> below
+can be implemented by a "South pole rotation" with the following parameters:
+
+* φ<sub>p</sub>  = −φ<sub>N</sub>
+* λ<sub>p</sub>  =  λ<sub>N</sub> − copySign(180, λ<sub>N</sub>)
+* θ<sub>p</sub>  = −θ<sub>N</sub>
+
+
+### Inverse operation
+Conversion from the rotated CRS to the geographic CRS can be done using the same "North pole rotation" method,
+but with all parameters with subscript <var>N</var> replaced by following parameters with subscript <var>g</var>:
+
+* φ<sub>g</sub>  = φ<sub>N</sub>
+* λ<sub>g</sub>  = θ<sub>N</sub>
+* θ<sub>g</sub>  = λ<sub>N</sub>
 
 
 #### Open question
 Axis rotation has been defined as "clockwise when looking from the northern to the southern rotated pole"
 for symmetry with the definition in South pole case.
-But it causes a change of sign (+θ instead of −θ) for the last term in above formula.
-Should be change the definition in a way that keep the same sign,
-for example by replacing "clockwise" by "counter-clockwise" in the North pole case?
-
-#### Open issue
-`ucar.unidata.geoloc.projection.RotatedPole` in UCAR netCDF library version 5.5.2 gives results
-with an offset of 180° in longitude values compared to what we would expect from a geometrical reasoning:
-if we rotate the pole to 60°N, then latitude of 59°N on Greenwich meridian become only 1° below new pole,
-i.e. 89°N, but still on the same meridian (Greenwich) because we did not cross the pole. Conversely 61°N
-is still at 89°N relative to the rotated pole, but on the other side of the pole, i.e. at longitude 180°.
-But `RotatedPole` gives opposite longitude values (180° and 0° respectively).
-
-The "South pole rotation" method of netCDF library is consistent with this geometrical reasoning.
-We do not know if the difference observed for "North pole rotation" is intended or not.
+It also produces more symetrical formulas in this section.
+But we found no authoritative source saying if the rotation should be clockwise or counter-clockwise.
 
 
 ## Rotated ellipsoidal coordinate system
@@ -193,9 +202,108 @@ GEODCRS["COSMO-DWD rotated pole grid",
   REMARK["Used with grid spacing of 0.025° in rotated coordinates."]]
 ```
 
-Converting a central point in Germany (51.1657°N 10.4515°E) gives about (1.1666°N 179.71682°W).
-It was tested with both Apache SIS using XML definition and PROJ using following command line:
+Converting a central point in Germany (51.1657°N 10.4515°E) gives about (1.1666°N 0.2832°W).
+It can be tested with UCAR, PROJ and Apache SIS as below:
+
+
+## UCAR netCDF library
+The UCAR library has been used as a reference for both PROJ `ob_tran` mapping and for Apache SIS.
+The code below is a snippet of Java code for converting the above-cited test coordinates.
+Note that this code provides no datum information; it is purely the pole rotation method with nothing else.
+
+```java
+var point    = ucar.unidata.geoloc.LatLonPoint.create(51.1657, 10.4515);
+var rotation = new ucar.unidata.geoloc.projection.RotatedPole(40, -170);
+System.out.println(rotation.latLonToProj(point));
+```
+
+Output:
 
 ```
-cs2cs -I "EPSG:4326" +to +type=crs +proj=ob_tran +o_proj=longlat +datum=WGS84 +no_defs +o_lat_p=40 +o_lon_p=-170
+.2831 1.166
 ```
+
+
+## PROJ command line
+The following command-line can be executed on a Unix system.
+Note that this command pretends that the CRS uses the WGS84 datum.
+This is not exact; the COSMO definition uses a datum close (but not identical)
+to _International 1924 Authalic Sphere_ (`urn:ogc:def:datum:EPSG::6053`).
+However the `ob_tran` method ignores the ellipsoid, because formulas are applied on a sphere
+(like all other implementations tested on this page)
+and the source and target coordinates are geographic coordinates on the same sphere.
+The use of "WGS84" and "EPSG:4326" below are geodetically wrong,
+but we abuse them for the convenience of using well-known aliases in this command-line
+with the knowledge that PROJ will ignore them.
+See Apache SIS case for a discussion on the impact of the datum on output coordinates.
+
+```shell
+cs2cs -I "EPSG:4326" +to +type=crs +proj=ob_tran +o_proj=longlat +datum=WGS84 +no_defs \
+      +o_lat_p=40 +o_lon_p=-170 +lon_0=180 -f %g <<< "10.4515 51.1657"
+```
+
+Output:
+
+```
+1.16655	0.283179 0
+```
+
+Reminder: despite the datum specified in command-line, above inputs are **not** WGS 84 coordinates.
+They are closer to "International 1924" coordinates. See discussion about datum below.
+If desired, transformation from/to WGS 84 can be added using more PROJ parameters.
+
+
+## Apache SIS
+Apache SIS can read GML, so it can be used for testing the [RotatedPole.xml](RotatedPole.xml) definition file directly.
+In the following command-line, replace `RotatedPole.xml` by
+[this URL](https://raw.githubusercontent.com/opengeospatial/MetOceanDWG/main/MetOceanDWG%20Projects/Authority%20Codes%20for%20CRS/RotatedPole.xml)
+(edit URL path if the location of `RotatedPole.xml` file changed) or a local copy of that file.
+This command requires SIS version 1.2 or above,
+because the "North pole rotation" method was not available in SIS 1.1.
+
+```shell
+sis transform --sourceCRS EPSG:4053 --targetCRS "RotatedPole.xml" <<< "51.1657, 10.4515"
+```
+
+Output:
+
+```
+# Source:      Unspecified datum based upon the International 1924 Authalic Sphere (EPSG:4053)
+# Destination: COSMO-DWD rotated pole grid (COSMO:101)
+# Operations:  Abridged Molodensky → COSMO-DE pole rotation (COSMO:101)
+# Accuracy:    3000.0 metres
+
+Rotated latitude (°), Rotated longitude (°)
+    1.166554714,      0.283179132
+```
+
+### Discussion about datum
+Above command used "International 1924 Authalic Sphere", which is a sphere of radius 6371228 meters.
+This is very close to the COSMO model, which uses a sphere of radius 6371229 meters, but not identical.
+The one meter difference is the reason why Apache SIS inserted an "Abridged Molodensky" operation before the pole rotation.
+Since that operation is not referenced in the EPSG database, this is considered as a datum shift of unknown accuracy.
+In such case SIS conservatively reports a 3 km accuracy as the worst case scenario.
+The result is nevertheless close to UCAR and PROJ results because of similarity between the two spheres.
+
+If we replace EPSG:4053 (International 1924) by EPSG:4326 (WGS 84) in the command-line:
+
+```shell
+sis transform --sourceCRS EPSG:4326 --targetCRS "RotatedPole.xml" <<< "51.1657, 10.4515"
+```
+
+Then the result become:
+
+```
+# Source:      WGS 84 (EPSG:4326)
+# Destination: COSMO-DWD rotated pole grid (COSMO:101)
+# Operations:  Abridged Molodensky → COSMO-DE pole rotation (COSMO:101)
+# Accuracy:    3000.0 metres
+
+Rotated latitude (°), Rotated longitude (°)
+    0.978570118,      0.284314319
+```
+
+The difference between the two results is about 20 km.
+Users should be careful about whether their tools apply a datum shift or not.
+In this example, the datum shift is only a change of ellipsoid axis lengths and flattening factors,
+without Bursa-Wolf parameters or Helmert transformation.

--- a/MetOceanDWG Projects/Authority Codes for CRS/PoleRotation.xml
+++ b/MetOceanDWG Projects/Authority Codes for CRS/PoleRotation.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:OperationMethod
+  xsi:schemaLocation = "http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/coordinateReferenceSystems.xsd"
+  xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml          = "http://www.opengis.net/gml/3.2"
+  gml:id="PoleRotation">
+  <gml:identifier codeSpace="OGC">urn:ogc:def:method:OGC::110</gml:identifier>
+  <gml:name codeSpace="OGC">North pole rotation</gml:name>
+  <gml:formula>See netCDF-CF conventions, section "Rotated Pole".</gml:formula>
+  <gml:sourceDimensions>2</gml:sourceDimensions>
+  <gml:targetDimensions>2</gml:targetDimensions>
+  <gml:parameter>
+    <gml:OperationParameter gml:id="PoleLatitude">
+      <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::111</gml:identifier>
+      <gml:name codeSpace="OGC">Latitude of rotated pole</gml:name>
+    </gml:OperationParameter>
+  </gml:parameter>
+  <gml:parameter>
+    <gml:OperationParameter gml:id="PoleLongitude">
+      <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::112</gml:identifier>
+      <gml:name codeSpace="OGC">Longitude of rotated pole</gml:name>
+    </gml:OperationParameter>
+  </gml:parameter>
+  <gml:parameter>
+    <gml:OperationParameter gml:id="AxisRotation">
+      <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::113</gml:identifier>
+      <gml:name codeSpace="OGC">Axis rotation</gml:name>
+    </gml:OperationParameter>
+  </gml:parameter>
+</gml:OperationMethod>

--- a/MetOceanDWG Projects/Authority Codes for CRS/RotatedCS.xml
+++ b/MetOceanDWG Projects/Authority Codes for CRS/RotatedCS.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gml:EllipsoidalCS
+  xsi:schemaLocation = "http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/coordinateReferenceSystems.xsd"
+  xmlns:xsi          = "http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml          = "http://www.opengis.net/gml/3.2"
+  gml:id="rotated-CS">
+  <gml:identifier codeSpace="OGC">urn:ogc:def:cs:OGC::100</gml:identifier>
+  <gml:name>Ellipsoidal rotated CS.</gml:name>
+  <gml:axis>
+    <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-latitude">
+      <gml:identifier codeSpace="OGC">urn:ogc:def:axis:OGC::101</gml:identifier>
+      <gml:name>Rotated latitude</gml:name>
+      <gml:axisAbbrev>φ</gml:axisAbbrev>
+      <gml:axisDirection codeSpace="ISO">north</gml:axisDirection>
+      <gml:minimumValue>-90.0</gml:minimumValue>
+      <gml:maximumValue>90.0</gml:maximumValue>
+      <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
+    </gml:CoordinateSystemAxis>
+  </gml:axis>
+  <gml:axis>
+    <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-longitude">
+      <gml:identifier codeSpace="OGC">urn:ogc:def:axis:OGC::102</gml:identifier>
+      <gml:name>Rotated longitude</gml:name>
+      <gml:axisAbbrev>λ</gml:axisAbbrev>
+      <gml:axisDirection codeSpace="ISO">east</gml:axisDirection>
+      <gml:minimumValue>-180.0</gml:minimumValue>
+      <gml:maximumValue>180.0</gml:maximumValue>
+      <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
+    </gml:CoordinateSystemAxis>
+  </gml:axis>
+</gml:EllipsoidalCS>

--- a/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
+++ b/MetOceanDWG Projects/Authority Codes for CRS/RotatedPole.xml
@@ -8,12 +8,12 @@
   xmlns:xlink        = "http://www.w3.org/1999/xlink"
   gml:id="cosmo-crs-101">
   <gml:identifier codeSpace="COSMO">urn:ogc:def:crs:COSMO::101</gml:identifier>
-  <gml:name codeSpace="COSMO">COSMO reference system</gml:name>
-  <gml:remarks>Tentative CRS definition. May change in any future version.</gml:remarks>
+  <gml:name codeSpace="COSMO">COSMO-DWD rotated pole grid</gml:name>
+  <gml:remarks>Used with grid spacing of 0.025° in rotated coordinates.</gml:remarks>
   <gml:domainOfValidity>
     <gmd:EX_Extent>
       <gmd:description>
-        <gco:CharacterString>Park of (TODO).</gco:CharacterString>
+        <gco:CharacterString>Central Germany.</gco:CharacterString>
       </gmd:description>
       <gmd:geographicElement>
         <gmd:EX_GeographicBoundingBox>
@@ -21,63 +21,63 @@
               <gco:Boolean>true</gco:Boolean>
             </gmd:extentTypeCode>
             <gmd:westBoundLongitude>
-              <gco:Decimal>10</gco:Decimal>         <!-- TODO -->
+              <gco:Decimal>5</gco:Decimal>
             </gmd:westBoundLongitude>
             <gmd:eastBoundLongitude>
-              <gco:Decimal>80</gco:Decimal>         <!-- TODO -->
+              <gco:Decimal>15</gco:Decimal>
             </gmd:eastBoundLongitude>
             <gmd:southBoundLatitude>
-              <gco:Decimal>40</gco:Decimal>         <!-- TODO -->
+              <gco:Decimal>47</gco:Decimal>
             </gmd:southBoundLatitude>
             <gmd:northBoundLatitude>
-              <gco:Decimal>60</gco:Decimal>         <!-- TODO -->
+              <gco:Decimal>55</gco:Decimal>
             </gmd:northBoundLatitude>
         </gmd:EX_GeographicBoundingBox>
       </gmd:geographicElement>
     </gmd:EX_Extent>
   </gml:domainOfValidity>
-  <gml:scope>Specific to COSMO project.</gml:scope>     <!-- TODO -->
+  <gml:scope>Atmospheric model data.</gml:scope>
   <gml:conversion>
     <gml:Conversion gml:id="RotatedLatLon">
-      <gml:identifier codeSpace="COSMO">urn:ogc:def:coordinateOperation:COSMO::100</gml:identifier>
-      <gml:name codeSpace="COSMO">Rotated Latitude Longitude</gml:name>
-      <gml:scope>Specific to COSMO project.</gml:scope>                                     <!-- TODO -->
+      <gml:identifier codeSpace="COSMO">urn:ogc:def:coordinateOperation:COSMO::101</gml:identifier>
+      <gml:name codeSpace="COSMO">COSMO-DE pole rotation</gml:name>
+      <gml:scope>Atmospheric model data.</gml:scope>
       <gml:method>
         <gml:OperationMethod gml:id="PoleRotation">
-          <gml:identifier codeSpace="COSMO">urn:ogc:def:method:COSMO::100</gml:identifier>
-          <gml:name codeSpace="COSMO">Pole rotation (netCDF CF convention)</gml:name>
+          <gml:identifier codeSpace="OGC">urn:ogc:def:method:OGC::110</gml:identifier>
+          <gml:name codeSpace="OGC">North pole rotation</gml:name>
           <gml:formula>See netCDF-CF conventions, section "Rotated Pole".</gml:formula>
           <gml:sourceDimensions>2</gml:sourceDimensions>
           <gml:targetDimensions>2</gml:targetDimensions>
           <gml:parameter>
             <gml:OperationParameter gml:id="PoleLatitude">
-              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::101</gml:identifier>
-              <gml:name codeSpace="COSMO">Grid north pole latitude</gml:name>
+              <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::111</gml:identifier>
+              <gml:name codeSpace="OGC">Latitude of rotated pole</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
           <gml:parameter>
             <gml:OperationParameter gml:id="PoleLongitude">
-              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::102</gml:identifier>
-              <gml:name codeSpace="COSMO">Grid north pole longitude</gml:name>
+              <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::112</gml:identifier>
+              <gml:name codeSpace="OGC">Longitude of rotated pole</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
           <gml:parameter>
             <gml:OperationParameter gml:id="AxisRotation">
-              <gml:identifier codeSpace="COSMO">urn:ogc:def:parameter:COSMO::103</gml:identifier>
-              <gml:name codeSpace="COSMO">North pole grid longitude</gml:name>
+              <gml:identifier codeSpace="OGC">urn:ogc:def:parameter:OGC::113</gml:identifier>
+              <gml:name codeSpace="OGC">Axis rotation</gml:name>
             </gml:OperationParameter>
           </gml:parameter>
         </gml:OperationMethod>
       </gml:method>
       <gml:parameterValue>
         <gml:ParameterValue>
-          <gml:value uom="urn:ogc:def:uom:EPSG::9102">39.25</gml:value>
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">40</gml:value>
           <gml:operationParameter xlink:href="#PoleLatitude"></gml:operationParameter>
         </gml:ParameterValue>
       </gml:parameterValue>
       <gml:parameterValue>
         <gml:ParameterValue>
-          <gml:value uom="urn:ogc:def:uom:EPSG::9102">-162</gml:value>
+          <gml:value uom="urn:ogc:def:uom:EPSG::9102">-170</gml:value>
           <gml:operationParameter xlink:href="#PoleLongitude"></gml:operationParameter>
         </gml:ParameterValue>
       </gml:parameterValue>
@@ -92,12 +92,12 @@
   <gml:baseCRS>
     <gml:GeodeticCRS gml:id="cosmo-crs-100">
       <gml:identifier codeSpace="COSMO">urn:ogc:def:crs:COSMO::100</gml:identifier>
-      <gml:name codeSpace="COSMO">COSMO base geodetic CRS</gml:name>
-      <gml:scope>Specific to COSMO project.</gml:scope>
+      <gml:name codeSpace="COSMO">COSMO DWD base geodetic CRS (spherical)</gml:name>
+      <gml:scope>Atmospheric model data.</gml:scope>
       <gml:ellipsoidalCS>
         <gml:EllipsoidalCS gml:id="epsg-cs-6422">
           <gml:identifier codeSpace="IOGP">urn:ogc:def:cs:EPSG:9.9.1:6422</gml:identifier>
-          <gml:name>Ellipsoidal CS: East (°), North (°).</gml:name>
+          <gml:name>Ellipsoidal CS: North (°), East (°).</gml:name>
           <gml:axis>
             <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="epsg-axis-106">
               <gml:identifier codeSpace="IOGP">urn:ogc:def:axis:EPSG:9.9.1:106</gml:identifier>
@@ -123,10 +123,10 @@
         </gml:EllipsoidalCS>
       </gml:ellipsoidalCS>
       <gml:geodeticDatum>
-        <gml:GeodeticDatum gml:id="COSMOKugel">
+        <gml:GeodeticDatum gml:id="cosmo-datum-100">
           <gml:identifier codeSpace="COSMO">urn:ogc:def:datum:COSMO::100</gml:identifier>
-          <gml:name>COSMO Kugel</gml:name>
-          <gml:scope>Specific to COSMO project.</gml:scope>
+          <gml:name>COSMO DWD geodetic datum (spherical)</gml:name>
+          <gml:scope>Atmospheric model data.</gml:scope>
           <gml:primeMeridian>
             <gml:PrimeMeridian gml:id="epsg-meridian-8901">
               <gml:identifier codeSpace="IOGP">urn:ogc:def:meridian:EPSG::8901</gml:identifier>
@@ -135,9 +135,9 @@
             </gml:PrimeMeridian>
           </gml:primeMeridian>
           <gml:ellipsoid>
-            <gml:Ellipsoid gml:id="Erdkugel">
+            <gml:Ellipsoid gml:id="cosmo-sphere-100">
               <gml:identifier codeSpace="COSMO">urn:ogc:def:ellipsoid:COSMO::100</gml:identifier>
-              <gml:name>Erdkugel</gml:name>
+              <gml:name>COSMO DWD models sphere</gml:name>
               <gml:semiMajorAxis uom="urn:ogc:def:uom:EPSG::9001">6371229.0</gml:semiMajorAxis>
               <gml:secondDefiningParameter>
                 <gml:SecondDefiningParameter>
@@ -153,14 +153,14 @@
   <gml:derivedCRSType codeSpace="ISO">GeodeticCRS</gml:derivedCRSType>
   <gml:coordinateSystem>
     <gml:EllipsoidalCS gml:id="rotated-CS">
-      <gml:identifier codeSpace="COSMO">urn:ogc:def:cs:COSMO::101</gml:identifier>
+      <gml:identifier codeSpace="OGC">urn:ogc:def:cs:OGC::100</gml:identifier>
       <gml:name>Ellipsoidal rotated CS.</gml:name>
       <gml:axis>
         <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-latitude">
-          <gml:identifier codeSpace="COSMO">urn:ogc:def:axis:COSMO::101</gml:identifier>
+          <gml:identifier codeSpace="OGC">urn:ogc:def:axis:OGC::101</gml:identifier>
           <gml:name>Rotated latitude</gml:name>
           <gml:axisAbbrev>φ</gml:axisAbbrev>
-          <gml:axisDirection codeSpace="COSMO">north</gml:axisDirection>
+          <gml:axisDirection codeSpace="ISO">north</gml:axisDirection>
           <gml:minimumValue>-90.0</gml:minimumValue>
           <gml:maximumValue>90.0</gml:maximumValue>
           <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>
@@ -168,10 +168,10 @@
       </gml:axis>
       <gml:axis>
         <gml:CoordinateSystemAxis uom="urn:ogc:def:uom:EPSG::9122" gml:id="rotated-longitude">
-          <gml:identifier codeSpace="COSMO">urn:ogc:def:axis:COSMO::102</gml:identifier>
+          <gml:identifier codeSpace="OGC">urn:ogc:def:axis:OGC::102</gml:identifier>
           <gml:name>Rotated longitude</gml:name>
           <gml:axisAbbrev>λ</gml:axisAbbrev>
-          <gml:axisDirection codeSpace="COSMO">east</gml:axisDirection>
+          <gml:axisDirection codeSpace="ISO">east</gml:axisDirection>
           <gml:minimumValue>-180.0</gml:minimumValue>
           <gml:maximumValue>180.0</gml:maximumValue>
           <gml:rangeMeaning codeSpace="ISO">exact</gml:rangeMeaning>


### PR DESCRIPTION
Those commits remove the "North pole rotation" formulas and replace them by "South pole rotation" working on the antipodal point. This change is based on a reading of [Nonhydrostatic Regional COSMO-Model](http://cosmo-model.org/content/model/documentation/core/cosmo_dynamics_6.0.pdf) §2.3:

> It is convenient to define the rotated meridian which runs through both the geographical and the rotated North Pole as the 0◦ meridian.

This sentence solves de 180° offset issue mentioned in previous version. The new approach described in the new version "automagically" inserts the 180° offset for complying with above quote.

This commit also adds:
* Formulas for inverse conversion.
* XML files for 2 components that could be subject to OGC standardization.
* Example using UCAR, PROJ and Apache SIS.
